### PR TITLE
(fix) remove utf-8-unix local var for Windows (#5)

### DIFF
--- a/binder.el
+++ b/binder.el
@@ -1444,7 +1444,6 @@ See `binder-sidebar-toggle-include'."
 ;;; binder.el ends here
 
 ;; Local Variables:
-;; coding: utf-8-unix
 ;; fill-column: 80
 ;; indent-tabs-mode: nil
 ;; require-final-newline: t

--- a/binder.el
+++ b/binder.el
@@ -1444,6 +1444,7 @@ See `binder-sidebar-toggle-include'."
 ;;; binder.el ends here
 
 ;; Local Variables:
+;; coding: utf-8
 ;; fill-column: 80
 ;; indent-tabs-mode: nil
 ;; require-final-newline: t


### PR DESCRIPTION
I realize Binder is still in the alpha state. Please see issue #5 I opened.
Thank you.